### PR TITLE
Support block assignments' `endset` keyword

### DIFF
--- a/syntax/jinja.vim
+++ b/syntax/jinja.vim
@@ -26,7 +26,7 @@ syn keyword jinjaStatement contained raw endraw
 syn keyword jinjaStatement contained block endblock extends super scoped
 syn keyword jinjaStatement contained macro endmacro call endcall
 syn keyword jinjaStatement contained from import as do continue break
-syn keyword jinjaStatement contained filter endfilter set
+syn keyword jinjaStatement contained filter endfilter set endset
 syn keyword jinjaStatement contained include ignore missing
 syn keyword jinjaStatement contained with without context endwith
 syn keyword jinjaStatement contained trans endtrans pluralize


### PR DESCRIPTION
Hi @lepture, this adds highlighting for the `endset` keyword of [block assignments](https://jinja.palletsprojects.com/en/3.0.x/templates/#block-assignments) (introduced in Jinja v2.8).

This change works for me, but let me know if it's missing something.

Have a nice day!